### PR TITLE
Feature/duende identityserver 7.0.8

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -99,7 +99,7 @@ Task("Build")
             .WithProperty("Version", semVersion)
             .WithProperty("PackageVersion", gitVersionResults.MajorMinorPatch)
             .WithProperty("PackageOutputPath", MakeAbsolute(nugetPackageDir).FullPath)
-            .UseToolVersion(MSBuildToolVersion.VS2019)
+            .UseToolVersion(MSBuildToolVersion.VS2022)
             .SetNodeReuse(false);
 
             // setup binary logging for solution to artifacts dir

--- a/src/IdentityServer4.Contrib.Membership/IdentityServer4.Contrib.Membership.csproj
+++ b/src/IdentityServer4.Contrib.Membership/IdentityServer4.Contrib.Membership.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Copyright>Copyright © 2017 onwards</Copyright>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <RootNamespace>IdentityServer4.Contrib.Membership</RootNamespace>
     <PackageId>Sitecore.IdentityServer4.Contrib.Membership</PackageId>
@@ -22,13 +22,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Duende.IdentityServer" Version="6.0.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.5" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+    <PackageReference Include="Duende.IdentityServer" Version="7.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Data.SqlClient" Version="4.5.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>
 
 </Project>

--- a/src/IdentityServer4.Contrib.Membership/IdentityServer4.Contrib.Membership.csproj
+++ b/src/IdentityServer4.Contrib.Membership/IdentityServer4.Contrib.Membership.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Duende.IdentityServer" Version="7.0.5" />
+    <PackageReference Include="Duende.IdentityServer" Version="7.0.6" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/IdentityServer4.Contrib.Membership/IdentityServer4.Contrib.Membership.csproj
+++ b/src/IdentityServer4.Contrib.Membership/IdentityServer4.Contrib.Membership.csproj
@@ -22,8 +22,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Duende.IdentityServer" Version="7.0.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Duende.IdentityServer" Version="7.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/samples/IdentityServer4.Contrib.Membership.ClientDemo/IdentityServer4.Contrib.Membership.ClientDemo.csproj
+++ b/src/samples/IdentityServer4.Contrib.Membership.ClientDemo/IdentityServer4.Contrib.Membership.ClientDemo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/samples/IdentityServer4.Contrib.Membership.IdsvrDemo/IdentityServer4.Contrib.Membership.IdsvrDemo.csproj
+++ b/src/samples/IdentityServer4.Contrib.Membership.IdsvrDemo/IdentityServer4.Contrib.Membership.IdsvrDemo.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="4.0.0" />
+    <PackageReference Include="Serilog" Version="4.0.2" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
   </ItemGroup>

--- a/src/samples/IdentityServer4.Contrib.Membership.IdsvrDemo/IdentityServer4.Contrib.Membership.IdsvrDemo.csproj
+++ b/src/samples/IdentityServer4.Contrib.Membership.IdsvrDemo/IdentityServer4.Contrib.Membership.IdsvrDemo.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.8.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog" Version="4.0.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Update sitecore-identityserver-contrib-membership repo to .NET 8.0 LTS (Long Term Support).
- Consume latest and stable duende identity server **7.0.8  version**